### PR TITLE
Reserve space for the NUL terminator

### DIFF
--- a/src/desktop-trampoline.c
+++ b/src/desktop-trampoline.c
@@ -102,7 +102,7 @@ int runTrampolineClient(SOCKET *outSocket, int argc, char **argv, char **envp) {
 
   // TODO: send stdin stuff?
 
-  char buffer[BUFFER_LENGTH];
+  char buffer[BUFFER_LENGTH + 1];
   size_t totalBytesRead = 0;
   ssize_t bytesRead = 0;
 


### PR DESCRIPTION
If we read exactly `BUFFER_LENGTH` characters then we will overflow the buffer
when writing the NUL terminator. We need to reserve one extra character for the
NUL terminator.