### PR TITLE
Add support for forwarding stdin data to server, and getting stdout and stderr from server

### DIFF
--- a/src/desktop-trampoline.c
+++ b/src/desktop-trampoline.c
@@ -134,9 +134,7 @@ int runTrampolineClient(SOCKET *outSocket, int argc, char **argv, char **envp) {
     totalBytesWritten += bytesToWrite;
   } while (bytesToWrite > 0);
 
-  if (totalBytesWritten > 0) {
-    writeSocket(socket, "\0", 1);
-  }
+  writeSocket(socket, "\0", 1);
 
   size_t totalBytesRead = 0;
   ssize_t bytesRead = 0;

--- a/src/desktop-trampoline.c
+++ b/src/desktop-trampoline.c
@@ -1,6 +1,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -61,13 +61,17 @@ describe('desktop-trampoline', () => {
 
     await run(trampolinePath, ['baz'], opts)
 
+    console.log(output)
+
     const outputArguments = output.slice(1, 2)
     expect(outputArguments).toStrictEqual(['baz'])
     // output[2] is the number of env variables
-    const outputEnv = output.slice(3)
+    const outputEnv = output.slice(3, output.length - 1)
     expect(outputEnv).toHaveLength(2)
     expect(outputEnv).toContain('DESKTOP_TRAMPOLINE_IDENTIFIER=123456')
     expect(outputEnv).toContain(`DESKTOP_USERNAME=sergiou87`)
+
+    expect(output[output.length - 1]).toStrictEqual('')
 
     server.close()
   })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,6 +9,33 @@ const { createServer } = require('net')
 const trampolinePath = getDesktopTrampolinePath()
 const run = promisify(execFile)
 
+async function startTrampolineServer(output) {
+  const server = createServer(socket => {
+    socket.pipe(split2(/\0/)).on('data', data => {
+      output.push(data.toString('utf8'))
+    })
+
+    // Don't send anything and just close the socket after the trampoline is
+    // done forwarding data.
+    socket.end()
+  })
+  server.unref()
+
+  const startServer = async () => {
+    return new Promise((resolve, reject) => {
+      server.on('error', e => reject(e))
+      server.listen(0, '127.0.0.1', () => {
+        resolve(server.address().port)
+      })
+    })
+  }
+
+  return {
+    server,
+    port: await startServer(),
+  }
+}
+
 describe('desktop-trampoline', () => {
   it('exists and is a regular file', async () =>
     expect((await stat(trampolinePath)).isFile()).toBe(true))
@@ -19,29 +46,10 @@ describe('desktop-trampoline', () => {
   it('fails when required environment variables are missing', () =>
     expect(run(trampolinePath, ['Username'])).rejects.toThrow())
 
-  it('forwards arguments and valid environment variables correctly', async () => {
+  it('forwards arguments and valid environment variables correctly without stdin', async () => {
     const output = []
-    const server = createServer(socket => {
-      socket.pipe(split2(/\0/)).on('data', data => {
-        output.push(data.toString('utf8'))
-      })
+    const { server, port } = await startTrampolineServer(output)
 
-      // Don't send anything and just close the socket after the trampoline is
-      // done forwarding data.
-      socket.end()
-    })
-    server.unref()
-
-    const startTrampolineServer = async () => {
-      return new Promise((resolve, reject) => {
-        server.on('error', e => reject(e))
-        server.listen(0, '127.0.0.1', () => {
-          resolve(server.address().port)
-        })
-      })
-    }
-
-    const port = await startTrampolineServer()
     const env = {
       DESKTOP_TRAMPOLINE_IDENTIFIER: '123456',
       DESKTOP_PORT: port,
@@ -60,6 +68,56 @@ describe('desktop-trampoline', () => {
     expect(outputEnv).toHaveLength(2)
     expect(outputEnv).toContain('DESKTOP_TRAMPOLINE_IDENTIFIER=123456')
     expect(outputEnv).toContain(`DESKTOP_USERNAME=sergiou87`)
+
+    server.close()
+  })
+
+  it('forwards arguments, environment variables and stdin correctly', async () => {
+    const output = []
+    const { server, port } = await startTrampolineServer(output)
+
+    const env = {
+      DESKTOP_TRAMPOLINE_IDENTIFIER: '123456',
+      DESKTOP_PORT: port,
+      DESKTOP_USERNAME: 'sergiou87',
+    }
+    const opts = {
+      env,
+      stdin: 'This is a test\nWith a multiline\nStandard input text',
+    }
+
+    const run = new Promise((resolve, reject) => {
+      const process = execFile(trampolinePath, ['baz'], opts, function (
+        err,
+        stdout,
+        stderr
+      ) {
+        if (!err) {
+          resolve({ stdout, stderr, exitCode: 0 })
+          return
+        }
+
+        reject(err)
+      })
+
+      process.stdin.end(
+        'This is a test\nWith a multiline\nStandard input text',
+        'utf-8'
+      )
+    })
+    await run
+
+    const outputArguments = output.slice(1, 2)
+    expect(outputArguments).toStrictEqual(['baz'])
+    // output[2] is the number of env variables
+    const outputEnv = output.slice(3, output.length - 1)
+    expect(outputEnv).toHaveLength(2)
+    expect(outputEnv).toContain('DESKTOP_TRAMPOLINE_IDENTIFIER=123456')
+    expect(outputEnv).toContain(`DESKTOP_USERNAME=sergiou87`)
+
+    expect(output[output.length - 1]).toBe(
+      'This is a test\nWith a multiline\nStandard input text'
+    )
 
     server.close()
   })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,14 +9,25 @@ const { createServer } = require('net')
 const trampolinePath = getDesktopTrampolinePath()
 const run = promisify(execFile)
 
-async function startTrampolineServer(output) {
+async function startTrampolineServer(output, stdout = '', stderr = '') {
   const server = createServer(socket => {
     socket.pipe(split2(/\0/)).on('data', data => {
       output.push(data.toString('utf8'))
     })
 
-    // Don't send anything and just close the socket after the trampoline is
-    // done forwarding data.
+    const buffer = Buffer.alloc(2, 0)
+
+    // Send stdout
+    buffer.writeUInt16LE(stdout.length, 0)
+    socket.write(buffer)
+    socket.write(stdout)
+
+    // Send stderr
+    buffer.writeUInt16LE(stderr.length, 0)
+    socket.write(buffer)
+    socket.write(stderr)
+
+    // Close the socket
     socket.end()
   })
   server.unref()
@@ -46,83 +57,127 @@ describe('desktop-trampoline', () => {
   it('fails when required environment variables are missing', () =>
     expect(run(trampolinePath, ['Username'])).rejects.toThrow())
 
-  it('forwards arguments and valid environment variables correctly without stdin', async () => {
-    const output = []
-    const { server, port } = await startTrampolineServer(output)
+  describe('with a trampoline server', () => {
+    let server = null
+    let output = []
+    let baseEnv = {}
 
-    const env = {
-      DESKTOP_TRAMPOLINE_IDENTIFIER: '123456',
-      DESKTOP_PORT: port,
-      DESKTOP_USERNAME: 'sergiou87',
-      DESKTOP_USERNAME_FAKE: 'fake-user',
-      INVALID_VARIABLE: 'foo bar',
-    }
-    const opts = { env }
-
-    await run(trampolinePath, ['baz'], opts)
-
-    console.log(output)
-
-    const outputArguments = output.slice(1, 2)
-    expect(outputArguments).toStrictEqual(['baz'])
-    // output[2] is the number of env variables
-    const outputEnv = output.slice(3, output.length - 1)
-    expect(outputEnv).toHaveLength(2)
-    expect(outputEnv).toContain('DESKTOP_TRAMPOLINE_IDENTIFIER=123456')
-    expect(outputEnv).toContain(`DESKTOP_USERNAME=sergiou87`)
-
-    expect(output[output.length - 1]).toStrictEqual('')
-
-    server.close()
-  })
-
-  it('forwards arguments, environment variables and stdin correctly', async () => {
-    const output = []
-    const { server, port } = await startTrampolineServer(output)
-
-    const env = {
-      DESKTOP_TRAMPOLINE_IDENTIFIER: '123456',
-      DESKTOP_PORT: port,
-      DESKTOP_USERNAME: 'sergiou87',
-    }
-    const opts = {
-      env,
-      stdin: 'This is a test\nWith a multiline\nStandard input text',
+    async function configureTrampolineServer(stdout = '', stderr = '') {
+      output = []
+      const serverInfo = await startTrampolineServer(output, stdout, stderr)
+      server = serverInfo.server
+      baseEnv = {
+        DESKTOP_PORT: serverInfo.port,
+      }
     }
 
-    const run = new Promise((resolve, reject) => {
-      const process = execFile(trampolinePath, ['baz'], opts, function (
-        err,
-        stdout,
-        stderr
-      ) {
-        if (!err) {
-          resolve({ stdout, stderr, exitCode: 0 })
-          return
-        }
+    afterEach(() => {
+      server.close()
+    })
 
-        reject(err)
+    it('forwards arguments and valid environment variables correctly without stdin', async () => {
+      await configureTrampolineServer()
+
+      const env = {
+        ...baseEnv,
+        DESKTOP_TRAMPOLINE_IDENTIFIER: '123456',
+        DESKTOP_USERNAME: 'sergiou87',
+        DESKTOP_USERNAME_FAKE: 'fake-user',
+        INVALID_VARIABLE: 'foo bar',
+      }
+      const opts = { env }
+
+      await run(trampolinePath, ['baz'], opts)
+
+      const outputArguments = output.slice(1, 2)
+      expect(outputArguments).toStrictEqual(['baz'])
+      // output[2] is the number of env variables
+      const outputEnv = output.slice(3, output.length - 1)
+      expect(outputEnv).toHaveLength(2)
+      expect(outputEnv).toContain('DESKTOP_TRAMPOLINE_IDENTIFIER=123456')
+      expect(outputEnv).toContain(`DESKTOP_USERNAME=sergiou87`)
+
+      expect(output[output.length - 1]).toStrictEqual('')
+    })
+
+    it('forwards arguments, environment variables and stdin correctly', async () => {
+      await configureTrampolineServer()
+
+      const env = {
+        ...baseEnv,
+        DESKTOP_TRAMPOLINE_IDENTIFIER: '123456',
+        DESKTOP_USERNAME: 'sergiou87',
+      }
+      const opts = {
+        env,
+        stdin: 'This is a test\nWith a multiline\nStandard input text',
+      }
+
+      const run = new Promise((resolve, reject) => {
+        const process = execFile(trampolinePath, ['baz'], opts, function (
+          err,
+          stdout,
+          stderr
+        ) {
+          if (!err) {
+            resolve({ stdout, stderr, exitCode: 0 })
+            return
+          }
+
+          reject(err)
+        })
+
+        process.stdin.end(
+          'This is a test\nWith a multiline\nStandard input text',
+          'utf-8'
+        )
       })
+      await run
 
-      process.stdin.end(
-        'This is a test\nWith a multiline\nStandard input text',
-        'utf-8'
+      const outputArguments = output.slice(1, 2)
+      expect(outputArguments).toStrictEqual(['baz'])
+      // output[2] is the number of env variables
+      const outputEnv = output.slice(3, output.length - 1)
+      expect(outputEnv).toHaveLength(2)
+      expect(outputEnv).toContain('DESKTOP_TRAMPOLINE_IDENTIFIER=123456')
+      expect(outputEnv).toContain(`DESKTOP_USERNAME=sergiou87`)
+
+      expect(output[output.length - 1]).toBe(
+        'This is a test\nWith a multiline\nStandard input text'
       )
     })
-    await run
 
-    const outputArguments = output.slice(1, 2)
-    expect(outputArguments).toStrictEqual(['baz'])
-    // output[2] is the number of env variables
-    const outputEnv = output.slice(3, output.length - 1)
-    expect(outputEnv).toHaveLength(2)
-    expect(outputEnv).toContain('DESKTOP_TRAMPOLINE_IDENTIFIER=123456')
-    expect(outputEnv).toContain(`DESKTOP_USERNAME=sergiou87`)
+    it('outputs the same stdout received from the server, when no stderr is specified', async () => {
+      await configureTrampolineServer('This is the command stdout', '')
 
-    expect(output[output.length - 1]).toBe(
-      'This is a test\nWith a multiline\nStandard input text'
-    )
+      const opts = { env: baseEnv }
+      const result = await run(trampolinePath, ['baz'], opts)
 
-    server.close()
+      expect(result.stdout).toStrictEqual('This is the command stdout')
+      expect(result.stderr).toStrictEqual('')
+    })
+
+    it('outputs the same stderr received from the server, when no stdout is specified', async () => {
+      await configureTrampolineServer('', 'This is the command stderr')
+
+      const opts = { env: baseEnv }
+      const result = await run(trampolinePath, ['baz'], opts)
+
+      expect(result.stdout).toStrictEqual('')
+      expect(result.stderr).toStrictEqual('This is the command stderr')
+    })
+
+    it('outputs the same stdout and stderr received from the server, when both are specified', async () => {
+      await configureTrampolineServer(
+        'This is the command stdout',
+        'This is the command stderr'
+      )
+
+      const opts = { env: baseEnv }
+      const result = await run(trampolinePath, ['baz'], opts)
+
+      expect(result.stdout).toStrictEqual('This is the command stdout')
+      expect(result.stderr).toStrictEqual('This is the command stderr')
+    })
   })
 })


### PR DESCRIPTION
This PR introduces a few changes:
1. The trampoline reads info passed via `stdin` and forwards it to the server.
2. The server might send more data back to the trampoline, which will have to output in stdout and stderr.
3. Added tests for all the new things.
4. Refactor in those tests.