### PR TITLE
Improve logging on errors, specially on Windows

### DIFF
--- a/src/desktop-trampoline.c
+++ b/src/desktop-trampoline.c
@@ -66,7 +66,9 @@ int runTrampolineClient(SOCKET *outSocket, int argc, char **argv, char **envp) {
   *outSocket = socket;
 
   if (connectSocket(socket, desktopPort) != 0) {
-    printSocketError("ERROR: Couldn't connect to 127.0.0.1:%d", desktopPort);
+    printSocketError("ERROR: Couldn't connect to 127.0.0.1:%d - Please make "
+                     "sure you don't have an antivirus or firewall blocking "
+                     "this connection.", desktopPort);
     return 1;
   }
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -7,7 +7,16 @@
 #include <string.h>
 
 #ifdef WINDOWS
+
 #define MAX_WSA_ERROR_DESCRIPTION_LENGTH 4096
+
+void getWSALastErrorDescription(wchar_t *buffer, int bufferLength) {
+  FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, 
+                 NULL, WSAGetLastError(),
+                 MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                 (LPWSTR)buffer, bufferLength - 1, NULL);
+}
+
 #endif
 
 int initializeNetwork(void) {
@@ -63,17 +72,6 @@ int readSocket(SOCKET socket, void *buffer, size_t length) {
   return recv(socket, buffer, length, 0);
 }
 
-#ifdef WINDOWS
-
-void getWSALastErrorDescription(wchar_t *buffer, int maxLength) {
-  FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, 
-                 NULL, WSAGetLastError(),
-                 MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                 (LPWSTR)&buffer, maxLength, NULL);
-}
-
-#endif
-
 void printSocketError(char *fmt, ...) {
   char formatted_string[4096];
 
@@ -84,7 +82,7 @@ void printSocketError(char *fmt, ...) {
 
 #ifdef WINDOWS
   wchar_t errorDescription[MAX_WSA_ERROR_DESCRIPTION_LENGTH];
-  getWSALastErrorDescription(errorDescription, MAX_WSA_ERROR_DESCRIPTION_LENGTH)
+  getWSALastErrorDescription(errorDescription, MAX_WSA_ERROR_DESCRIPTION_LENGTH);
 
   fprintf(stderr, "%s (%ld): %ls\n", formatted_string, WSAGetLastError(), errorDescription);
 #else

--- a/src/socket.c
+++ b/src/socket.c
@@ -65,7 +65,13 @@ void printSocketError(char *fmt, ...)
   va_end(argptr);
 
 #ifdef WINDOWS
-  fprintf(stderr, "%s: %ld\n", formatted_string, WSAGetLastError());
+  wchar_t *errorDescription = NULL;
+  FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, 
+                 NULL, WSAGetLastError(),
+                 MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                 (LPWSTR)&errorDescription, 0, NULL);
+
+  fprintf(stderr, "%s (%ld): %S\n", formatted_string, WSAGetLastError(), errorDescription);
 #else
   fprintf(stderr, "%s (%d): %s\n", formatted_string, errno, strerror(errno));
 #endif


### PR DESCRIPTION
This PR has 2 changes:
- It adds the error description on Windows (adding the equivalent to `strerr`).
- It also adds some details to the connection error. This change is user-facing, and will suggest users to check their firewall/antivirus in case it's blocking the connection.