### PR TITLE
Release v0.9.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop-trampoline",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "main": "index.js",
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "test": "jest",
     "lint": "prettier -c **/*.js **/*.md",
     "lint:fix": "prettier --write **/*.js **/*.md",
-    "prebuild-napi-x64": "prebuild -t 3 -r napi -a x64 --strip --include-regex \"desktop-trampoline(\\.exe)?$\"",
-    "prebuild-napi-ia32": "prebuild -t 3 -r napi -a ia32 --strip --include-regex \"desktop-trampoline(\\.exe)?$\"",
-    "prebuild-napi-arm64": "prebuild -t 3 -r napi -a arm64 --strip --include-regex \"desktop-trampoline(\\.exe)?$\"",
+    "prebuild-napi-x64": "prebuild -t 3 -r napi -a x64 --strip --include-regex \"(desktop-trampoline|ssh-wrapper)(\\.exe)?$\"",
+    "prebuild-napi-ia32": "prebuild -t 3 -r napi -a ia32 --strip --include-regex \"(desktop-trampoline|ssh-wrapper)(\\.exe)?$\"",
+    "prebuild-napi-arm64": "prebuild -t 3 -r napi -a arm64 --strip --include-regex \"(desktop-trampoline|ssh-wrapper)(\\.exe)?$\"",
     "prebuild-all": "yarn prebuild-napi-x64 && yarn prebuild-napi-ia32 && yarn prebuild-napi-arm64",
     "upload": "node ./script/upload.js"
   },
@@ -36,7 +36,7 @@
   "devDependencies": {
     "jest": "^26.4.2",
     "node-gyp": "^7.1.0",
-    "prebuild": "^10.0.1",
+    "prebuild": "https://github.com/sergiou87/prebuild#strip-multiple-files",
     "prettier": "^2.1.2",
     "split2": "^3.2.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3452,10 +3452,9 @@ prebuild-install@^6.0.0:
     tar-fs "^2.0.0"
     tunnel-agent "^0.6.0"
 
-prebuild@^10.0.1:
+"prebuild@https://github.com/sergiou87/prebuild#strip-multiple-files":
   version "10.0.1"
-  resolved "https://registry.yarnpkg.com/prebuild/-/prebuild-10.0.1.tgz#9d46a00f42b60ad1718479cc5e3d1ef4882b7f33"
-  integrity sha512-x0CkKDmHFwX49rTGEYJwB9jBQwJWxRzwUtP5PA9dP8khFGMm3oSFgYortxdlp0PkxB29EhWGp/KQE5g+adehYg==
+  resolved "https://github.com/sergiou87/prebuild#d3761817d9a0db1ecf4dfbf12d02b36b0a03cadc"
   dependencies:
     cmake-js "~5.2.0"
     detect-libc "^1.0.3"


### PR DESCRIPTION
The only change in this version is the addition of the ssh wrapper that enables us to use `SSH_ASKPASS` from GitHub Desktop on macOS.

I changed `--include-regex` in `package.json` to make sure `ssh-wrapper` was included in the final prebuild bundles. Aside from changing `--include-regex`, I also needed to fix `prebuild` itself to support stripping debug symbols of multiple files: https://github.com/prebuild/prebuild/pull/280

Instead of waiting until that PR is merged, I went ahead and switched our `prebuild` dependency with my fork, containing my changes.