### PR TITLE
Create a separate credential helper trampoline

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The equivalent Bash shell code looks like this:
 
 ```sh
   # environment variable
-  GIT_ASKPASS="C:/some/path/to/desktop-trampoline.exe" \
+  GIT_ASKPASS="C:/some/path/to/desktop-askpass-trampoline.exe" \
   # ensure Git doesn't block the process waiting for the user to provide input
   GIT_TERMINAL_PROMPT=0 \
   git \

--- a/binding.gyp
+++ b/binding.gyp
@@ -56,6 +56,24 @@
         ]
       },
       {
+        'target_name': 'desktop-credential-helper-trampoline',
+        'type': 'executable',
+        'defines': [
+          'CREDENTIAL_HELPER'
+        ],
+        'sources': [
+          'src/desktop-trampoline.c',
+          'src/socket.c'
+        ],
+        'conditions': [
+          ['OS=="win"', {
+            'link_settings': {
+              'libraries': [ 'Ws2_32.lib' ]
+            }
+          }]
+        ]
+      },
+      {
         'target_name': 'ssh-wrapper',
         'type': 'executable',
         'sources': [

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,6 @@
         'defines': [
           "NAPI_VERSION=<(napi_build_version)",
         ],
-        'type': 'executable',
         'include_dirs': [
           '<!(node -p "require(\'node-addon-api\').include_dir")',
           'include'
@@ -43,6 +42,7 @@
     'targets': [
       {
         'target_name': 'desktop-trampoline',
+        'type': 'executable',
         'sources': [
           'src/desktop-trampoline.c',
           'src/socket.c'
@@ -57,6 +57,7 @@
       },
       {
         'target_name': 'ssh-wrapper',
+        'type': 'executable',
         'sources': [
           'src/ssh-wrapper.c'
         ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -41,7 +41,7 @@
     },
     'targets': [
       {
-        'target_name': 'desktop-trampoline',
+        'target_name': 'desktop-askpass-trampoline',
         'type': 'executable',
         'sources': [
           'src/desktop-trampoline.c',

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,15 +1,9 @@
   {
-    'targets': [
-      {
-        'target_name': 'desktop-trampoline',
+    'target_defaults': {
         'defines': [
           "NAPI_VERSION=<(napi_build_version)",
         ],
         'type': 'executable',
-        'sources': [
-          'src/desktop-trampoline.c',
-          'src/socket.c'
-        ],
         'include_dirs': [
           '<!(node -p "require(\'node-addon-api\').include_dir")',
           'include'
@@ -43,8 +37,18 @@
           'VCCLCompilerTool': { 'ExceptionHandling': 1 },
         },
         'conditions': [
+          ['OS=="win"', { 'defines': [ 'WINDOWS' ] }]
+        ]
+    },
+    'targets': [
+      {
+        'target_name': 'desktop-trampoline',
+        'sources': [
+          'src/desktop-trampoline.c',
+          'src/socket.c'
+        ],
+        'conditions': [
           ['OS=="win"', {
-            'defines': [ 'WINDOWS' ],
             'link_settings': {
               'libraries': [ 'Ws2_32.lib' ]
             }
@@ -53,51 +57,9 @@
       },
       {
         'target_name': 'ssh-wrapper',
-        'defines': [
-          "NAPI_VERSION=<(napi_build_version)",
-        ],
-        'type': 'executable',
         'sources': [
           'src/ssh-wrapper.c'
         ],
-        'include_dirs': [
-          '<!(node -p "require(\'node-addon-api\').include_dir")',
-          'include'
-        ],
-        'xcode_settings': {
-          'OTHER_CFLAGS': [
-            '-Wall',
-            '-Werror',
-            '-Werror=format-security',
-            '-fPIC',
-            '-D_FORTIFY_SOURCE=1',
-            '-fstack-protector-strong'
-          ]
-        },
-        'cflags!': [
-          '-Wall',
-          '-Werror',
-          '-fPIC',
-          '-pie',
-          '-D_FORTIFY_SOURCE=1',
-          '-fstack-protector-strong',
-          '-Werror=format-security',
-          '-fno-exceptions'
-        ],
-        'cflags_cc!': [ '-fno-exceptions' ],
-        'ldflags!': [
-          '-z relro',
-          '-z now'
-        ],
-        'msvs_settings': {
-          'VCCLCompilerTool': { 'ExceptionHandling': 1 },
-        },
-        'conditions': [
-          # For now only build it for macOS, since it's not needed on Windows
-          ['OS=="win"', {
-            'defines': [ 'WINDOWS' ],
-          }]
-        ]
       },
     ],
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
-export function getDesktopTrampolinePath(): string
-export function getDesktopTrampolineFilename(): string
+export function getDesktopAskpassTrampolinePath(): string
+export function getDesktopAskpassTrampolineFilename(): string
 
 export function getSSHWrapperPath(): string
 export function getSSHWrapperFilename(): string

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,8 @@
 export function getDesktopAskpassTrampolinePath(): string
 export function getDesktopAskpassTrampolineFilename(): string
 
+export function getDesktopCredentialHelperTrampolinePath(): string
+export function getDesktopCredentialHelperTrampolineFilename(): string
+
 export function getSSHWrapperPath(): string
 export function getSSHWrapperFilename(): string

--- a/index.js
+++ b/index.js
@@ -15,6 +15,21 @@ function getDesktopAskpassTrampolineFilename() {
     : 'desktop-askpass-trampoline'
 }
 
+function getDesktopCredentialHelperTrampolinePath() {
+  return Path.join(
+    __dirname,
+    'build',
+    'Release',
+    getDesktopCredentialHelperTrampolineFilename()
+  )
+}
+
+function getDesktopCredentialHelperTrampolineFilename() {
+  return process.platform === 'win32'
+    ? 'desktop-credential-helper-trampoline.exe'
+    : 'desktop-credential-helper-trampoline'
+}
+
 function getSSHWrapperPath() {
   return Path.join(__dirname, 'build', 'Release', getSSHWrapperFilename())
 }
@@ -26,6 +41,8 @@ function getSSHWrapperFilename() {
 module.exports = {
   getDesktopAskpassTrampolinePath,
   getDesktopAskpassTrampolineFilename,
+  getDesktopCredentialHelperTrampolinePath,
+  getDesktopCredentialHelperTrampolineFilename,
   getSSHWrapperPath,
   getSSHWrapperFilename,
 }

--- a/index.js
+++ b/index.js
@@ -1,18 +1,18 @@
 const Path = require('path')
 
-function getDesktopTrampolinePath() {
+function getDesktopAskpassTrampolinePath() {
   return Path.join(
     __dirname,
     'build',
     'Release',
-    getDesktopTrampolineFilename()
+    getDesktopAskpassTrampolineFilename()
   )
 }
 
-function getDesktopTrampolineFilename() {
+function getDesktopAskpassTrampolineFilename() {
   return process.platform === 'win32'
-    ? 'desktop-trampoline.exe'
-    : 'desktop-trampoline'
+    ? 'desktop-askpass-trampoline.exe'
+    : 'desktop-askpass-trampoline'
 }
 
 function getSSHWrapperPath() {
@@ -24,8 +24,8 @@ function getSSHWrapperFilename() {
 }
 
 module.exports = {
-  getDesktopTrampolinePath,
-  getDesktopTrampolineFilename,
+  getDesktopAskpassTrampolinePath,
+  getDesktopAskpassTrampolineFilename,
   getSSHWrapperPath,
   getSSHWrapperFilename,
 }

--- a/src/desktop-trampoline.c
+++ b/src/desktop-trampoline.c
@@ -137,9 +137,9 @@ int runTrampolineClient(SOCKET *outSocket, int argc, char **argv, char **envp) {
 int main(int argc, char **argv, char **envp) {
 
   #ifdef CREDENTIAL_HELPER
-    setenv("DESKTOP_TRAMPOLINE_IDENTIFIER", "CREDENTIALHELPER");
-  #elif
-    setenv("DESKTOP_TRAMPOLINE_IDENTIFIER", "ASKPASS");
+    setenv("DESKTOP_TRAMPOLINE_IDENTIFIER", "CREDENTIALHELPER", 1);
+  #else
+    setenv("DESKTOP_TRAMPOLINE_IDENTIFIER", "ASKPASS", 1);
   #endif
 
   if (initializeNetwork() != 0) {

--- a/src/desktop-trampoline.c
+++ b/src/desktop-trampoline.c
@@ -102,7 +102,15 @@ int runTrampolineClient(SOCKET *outSocket, int argc, char **argv, char **envp) {
     WRITE_STRING_OR_EXIT("environment variable", validEnvVars[idx]);
   }
 
-  // TODO: send stdin stuff?
+  char stdinBuffer[BUFFER_LENGTH + 1];
+  int stdinBytes = 0;
+
+  #ifdef CREDENTIAL_HELPER
+    stdinBytes = fread(stdinBuffer, sizeof(char), BUFFER_LENGTH, stdin);
+  #endif
+
+  stdinBuffer[stdinBytes] = '\0';
+  WRITE_STRING_OR_EXIT("stdin", stdinBuffer);
 
   char buffer[BUFFER_LENGTH + 1];
   size_t totalBytesRead = 0;
@@ -129,6 +137,13 @@ int runTrampolineClient(SOCKET *outSocket, int argc, char **argv, char **envp) {
 }
 
 int main(int argc, char **argv, char **envp) {
+
+  #ifdef CREDENTIAL_HELPER
+    setenv("DESKTOP_TRAMPOLINE_IDENTIFIER", "CREDENTIALHELPER");
+  #elif
+    setenv("DESKTOP_TRAMPOLINE_IDENTIFIER", "ASKPASS");
+  #endif
+
   if (initializeNetwork() != 0) {
     return 1;
   }

--- a/src/desktop-trampoline.c
+++ b/src/desktop-trampoline.c
@@ -6,10 +6,6 @@
 
 #include "socket.h"
 
-#ifdef WINDOWS
-#include <windows.h>
-#endif
-
 #define BUFFER_LENGTH 4096
 #define MAXIMUM_NUMBER_LENGTH 33
 
@@ -28,9 +24,8 @@ if (writeSocket(socket, dataString, strlen(dataString) + 1) != 0) { \
 
 // This is a list of valid environment variables that GitHub Desktop might
 // send or expect to receive.
-#define NUMBER_OF_VALID_ENV_VARS 2
+#define NUMBER_OF_VALID_ENV_VARS 1
 static const char *sValidEnvVars[NUMBER_OF_VALID_ENV_VARS] = {
-  "DESKTOP_TRAMPOLINE_IDENTIFIER",
   "DESKTOP_TRAMPOLINE_TOKEN",
 };
 
@@ -92,8 +87,9 @@ int runTrampolineClient(SOCKET *outSocket, int argc, char **argv, char **envp) {
   }
 
   // Get the number of environment variables
-  char *validEnvVars[NUMBER_OF_VALID_ENV_VARS];
-  int envc = 0;
+  char *validEnvVars[NUMBER_OF_VALID_ENV_VARS + 1];
+  validEnvVars[0] = "DESKTOP_TRAMPOLINE_IDENTIFIER=" DESKTOP_TRAMPOLINE_IDENTIFIER;
+  int envc = 1;
   for (char **env = envp; *env != 0; env++) {
     if (isValidEnvVar(*env)) {
       validEnvVars[envc] = *env;
@@ -146,13 +142,6 @@ int runTrampolineClient(SOCKET *outSocket, int argc, char **argv, char **envp) {
 }
 
 int main(int argc, char **argv, char **envp) {
-
-  #ifdef WINDOWS
-    SetEnvironmentVariable("DESKTOP_TRAMPOLINE_IDENTIFIER", DESKTOP_TRAMPOLINE_IDENTIFIER);
-  #else
-    setenv("DESKTOP_TRAMPOLINE_IDENTIFIER", DESKTOP_TRAMPOLINE_IDENTIFIER, 1);
-  #endif
-
   if (initializeNetwork() != 0) {
     return 1;
   }

--- a/src/desktop-trampoline.c
+++ b/src/desktop-trampoline.c
@@ -6,8 +6,19 @@
 
 #include "socket.h"
 
+#ifdef WINDOWS
+#include <windows.h>
+#endif
+
 #define BUFFER_LENGTH 4096
 #define MAXIMUM_NUMBER_LENGTH 33
+
+#ifdef CREDENTIAL_HELPER
+  #define DESKTOP_TRAMPOLINE_IDENTIFIER "CREDENTIALHELPER"
+#else
+  #define DESKTOP_TRAMPOLINE_IDENTIFIER "ASKPASS"
+#endif
+
 
 #define WRITE_STRING_OR_EXIT(dataName, dataString) \
 if (writeSocket(socket, dataString, strlen(dataString) + 1) != 0) { \
@@ -136,10 +147,10 @@ int runTrampolineClient(SOCKET *outSocket, int argc, char **argv, char **envp) {
 
 int main(int argc, char **argv, char **envp) {
 
-  #ifdef CREDENTIAL_HELPER
-    setenv("DESKTOP_TRAMPOLINE_IDENTIFIER", "CREDENTIALHELPER", 1);
+  #ifdef WINDOWS
+    SetEnvironmentVariable("DESKTOP_TRAMPOLINE_IDENTIFIER", DESKTOP_TRAMPOLINE_IDENTIFIER);
   #else
-    setenv("DESKTOP_TRAMPOLINE_IDENTIFIER", "ASKPASS", 1);
+    setenv("DESKTOP_TRAMPOLINE_IDENTIFIER", DESKTOP_TRAMPOLINE_IDENTIFIER, 1);
   #endif
 
   if (initializeNetwork() != 0) {

--- a/test/desktop-trampoline.test.js
+++ b/test/desktop-trampoline.test.js
@@ -43,7 +43,7 @@ describe('desktop-trampoline', () => {
 
     const port = await startTrampolineServer()
     const env = {
-      DESKTOP_TRAMPOLINE_IDENTIFIER: '123456',
+      DESKTOP_TRAMPOLINE_TOKEN: '123456',
       DESKTOP_PORT: port,
       INVALID_VARIABLE: 'foo bar',
     }
@@ -56,7 +56,7 @@ describe('desktop-trampoline', () => {
     // output[2] is the number of env variables
     const outputEnv = output.slice(3)
     expect(outputEnv).toHaveLength(1)
-    expect(outputEnv).toContain('DESKTOP_TRAMPOLINE_IDENTIFIER=123456')
+    expect(outputEnv).toContain('DESKTOP_TRAMPOLINE_TOKEN=123456')
 
     server.close()
   })

--- a/test/desktop-trampoline.test.js
+++ b/test/desktop-trampoline.test.js
@@ -2,11 +2,11 @@ const { stat, access } = require('fs').promises
 const { constants } = require('fs')
 const { execFile } = require('child_process')
 const { promisify } = require('util')
-const { getDesktopTrampolinePath } = require('../index')
+const { getDesktopAskpassTrampolinePath } = require('../index')
 const split2 = require('split2')
 const { createServer } = require('net')
 
-const trampolinePath = getDesktopTrampolinePath()
+const trampolinePath = getDesktopAskpassTrampolinePath()
 const run = promisify(execFile)
 
 describe('desktop-trampoline', () => {

--- a/test/desktop-trampoline.test.js
+++ b/test/desktop-trampoline.test.js
@@ -2,7 +2,10 @@ const { stat, access } = require('fs').promises
 const { constants } = require('fs')
 const { execFile } = require('child_process')
 const { promisify } = require('util')
-const { getDesktopAskpassTrampolinePath, getDesktopCredentialHelperTrampolinePath } = require('../index')
+const {
+  getDesktopAskpassTrampolinePath,
+  getDesktopCredentialHelperTrampolinePath,
+} = require('../index')
 const split2 = require('split2')
 const { createServer } = require('net')
 
@@ -59,7 +62,6 @@ describe('desktop-trampoline', () => {
   }
 
   it('forwards arguments and valid environment variables correctly', async () => {
-
     const [portPromise, outputPromise] = captureSession()
     const port = await portPromise
 
@@ -83,11 +85,12 @@ describe('desktop-trampoline', () => {
   })
 
   it('forwards stdin when running in credential-helper mode', async () => {
-
     const [portPromise, outputPromise] = captureSession()
     const port = await portPromise
 
-    const cp = run(helperTrampolinePath, ['get'], { env: { DESKTOP_PORT: port } })
+    const cp = run(helperTrampolinePath, ['get'], {
+      env: { DESKTOP_PORT: port },
+    })
     cp.child.stdin.end('oh hai\n')
 
     await cp
@@ -96,12 +99,13 @@ describe('desktop-trampoline', () => {
     expect(output.at(-1)).toBe('oh hai\n')
   })
 
-  it('doesn\'t forward stdin when running in askpass mode', async () => {
-
+  it("doesn't forward stdin when running in askpass mode", async () => {
     const [portPromise, outputPromise] = captureSession()
     const port = await portPromise
 
-    const cp = run(askPassTrampolinePath, ['get'], { env: { DESKTOP_PORT: port } })
+    const cp = run(askPassTrampolinePath, ['get'], {
+      env: { DESKTOP_PORT: port },
+    })
     cp.child.stdin.end('oh hai\n')
 
     await cp

--- a/test/desktop-trampoline.test.js
+++ b/test/desktop-trampoline.test.js
@@ -115,7 +115,7 @@ describe('desktop-trampoline', () => {
     expect(output.at(-1)).toBe('')
   })
 
-  it("askpass handler ignores the DESKTOP_TRAMPOLINE_IDENTIFIER env var", async () => {
+  it('askpass handler ignores the DESKTOP_TRAMPOLINE_IDENTIFIER env var', async () => {
     const [portPromise, outputPromise] = captureSession()
     const port = await portPromise
 
@@ -132,7 +132,7 @@ describe('desktop-trampoline', () => {
     expect(outputEnv).toContain('DESKTOP_TRAMPOLINE_IDENTIFIER=ASKPASS')
   })
 
-  it("credential handler ignores the DESKTOP_TRAMPOLINE_IDENTIFIER env var", async () => {
+  it('credential handler ignores the DESKTOP_TRAMPOLINE_IDENTIFIER env var', async () => {
     const [portPromise, outputPromise] = captureSession()
     const port = await portPromise
 
@@ -146,6 +146,8 @@ describe('desktop-trampoline', () => {
     const output = await outputPromise
     const envc = parseInt(output[2])
     const outputEnv = output.slice(3, 3 + envc)
-    expect(outputEnv).toContain('DESKTOP_TRAMPOLINE_IDENTIFIER=CREDENTIALHELPER')
+    expect(outputEnv).toContain(
+      'DESKTOP_TRAMPOLINE_IDENTIFIER=CREDENTIALHELPER'
+    )
   })
 })

--- a/test/desktop-trampoline.test.js
+++ b/test/desktop-trampoline.test.js
@@ -54,7 +54,8 @@ describe('desktop-trampoline', () => {
     const outputArguments = output.slice(1, 2)
     expect(outputArguments).toStrictEqual(['baz'])
     // output[2] is the number of env variables
-    const outputEnv = output.slice(3)
+    const envc = parseInt(output[2])
+    const outputEnv = output.slice(3, 3 + envc)
     expect(outputEnv).toHaveLength(1)
     expect(outputEnv).toContain('DESKTOP_TRAMPOLINE_TOKEN=123456')
 

--- a/test/desktop-trampoline.test.js
+++ b/test/desktop-trampoline.test.js
@@ -2,46 +2,67 @@ const { stat, access } = require('fs').promises
 const { constants } = require('fs')
 const { execFile } = require('child_process')
 const { promisify } = require('util')
-const { getDesktopAskpassTrampolinePath } = require('../index')
+const { getDesktopAskpassTrampolinePath, getDesktopCredentialHelperTrampolinePath } = require('../index')
 const split2 = require('split2')
 const { createServer } = require('net')
 
-const trampolinePath = getDesktopAskpassTrampolinePath()
+const askPassTrampolinePath = getDesktopAskpassTrampolinePath()
+const helperTrampolinePath = getDesktopCredentialHelperTrampolinePath()
 const run = promisify(execFile)
 
 describe('desktop-trampoline', () => {
   it('exists and is a regular file', async () =>
-    expect((await stat(trampolinePath)).isFile()).toBe(true))
+    expect((await stat(askPassTrampolinePath)).isFile()).toBe(true))
 
   it('can be executed by current process', () =>
-    access(trampolinePath, constants.X_OK))
+    access(askPassTrampolinePath, constants.X_OK))
 
   it('fails when required environment variables are missing', () =>
-    expect(run(trampolinePath, ['Username'])).rejects.toThrow())
+    expect(run(askPassTrampolinePath, ['Username'])).rejects.toThrow())
 
-  it('forwards arguments and valid environment variables correctly', async () => {
+  const captureSession = () => {
     const output = []
+    let resolveOutput = null
+
+    const outputPromise = new Promise(resolve => {
+      resolveOutput = resolve
+    })
+
     const server = createServer(socket => {
+      let timeoutId = null
       socket.pipe(split2(/\0/)).on('data', data => {
         output.push(data.toString('utf8'))
-      })
 
-      // Don't send anything and just close the socket after the trampoline is
-      // done forwarding data.
-      socket.end()
+        // Hack: consider the session finished after 100ms of inactivity.
+        // In a real-world scenario, you'd have to parse the data to know when
+        // the session is finished.
+        if (timeoutId !== null) {
+          clearTimeout(timeoutId)
+          timeoutId = null
+        }
+        timeoutId = setTimeout(() => {
+          resolveOutput(output)
+          socket.end()
+          server.close()
+        }, 100)
+      })
     })
-    server.unref()
 
-    const startTrampolineServer = async () => {
-      return new Promise((resolve, reject) => {
-        server.on('error', e => reject(e))
-        server.listen(0, '127.0.0.1', () => {
-          resolve(server.address().port)
-        })
+    const serverPortPromise = new Promise((resolve, reject) => {
+      server.on('error', e => reject(e))
+      server.listen(0, '127.0.0.1', () => {
+        resolve(server.address().port)
       })
-    }
+    })
 
-    const port = await startTrampolineServer()
+    return [serverPortPromise, outputPromise]
+  }
+
+  it('forwards arguments and valid environment variables correctly', async () => {
+
+    const [portPromise, outputPromise] = captureSession()
+    const port = await portPromise
+
     const env = {
       DESKTOP_TRAMPOLINE_TOKEN: '123456',
       DESKTOP_PORT: port,
@@ -49,8 +70,9 @@ describe('desktop-trampoline', () => {
     }
     const opts = { env }
 
-    await run(trampolinePath, ['baz'], opts)
+    await run(askPassTrampolinePath, ['baz'], opts)
 
+    const output = await outputPromise
     const outputArguments = output.slice(1, 2)
     expect(outputArguments).toStrictEqual(['baz'])
     // output[2] is the number of env variables
@@ -58,7 +80,33 @@ describe('desktop-trampoline', () => {
     const outputEnv = output.slice(3, 3 + envc)
     expect(outputEnv).toHaveLength(1)
     expect(outputEnv).toContain('DESKTOP_TRAMPOLINE_TOKEN=123456')
+  })
 
-    server.close()
+  it('forwards stdin when running in credential-helper mode', async () => {
+
+    const [portPromise, outputPromise] = captureSession()
+    const port = await portPromise
+
+    const cp = run(helperTrampolinePath, ['get'], { env: { DESKTOP_PORT: port } })
+    cp.child.stdin.end('oh hai\n')
+
+    await cp
+
+    const output = await outputPromise
+    expect(output.at(-1)).toBe('oh hai\n')
+  })
+
+  it('doesn\'t forward stdin when running in askpass mode', async () => {
+
+    const [portPromise, outputPromise] = captureSession()
+    const port = await portPromise
+
+    const cp = run(askPassTrampolinePath, ['get'], { env: { DESKTOP_PORT: port } })
+    cp.child.stdin.end('oh hai\n')
+
+    await cp
+
+    const output = await outputPromise
+    expect(output.at(-1)).toBe('')
   })
 })


### PR DESCRIPTION
When we're being invoked as an askpass handler we can't read from stdin or we'll be blocked forever. But when we're invoked as a credential helper we need to read stdin. So we're creating two binaries here that essentially only differ in whether or not they read stdin.

We're also no longer forwarding the DESKTOP_IDENTIFIER environment variable, that is instead hardcoded at compile time in the two binaries.