### PR TITLE
Update ci to default to Ubuntu 20.04 for prebuilds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,14 @@ jobs:
             friendlyName: macOS
           - os: windows-latest
             friendlyName: Windows
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             friendlyName: Linux
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - name: Install Python setup tools


### PR DESCRIPTION
Probably fix for https://github.com/shiftkey/desktop/issues/1207

When this binary is invoked on Linux, it's failing on environments where `GLIBC_2.34` is unavailable. I believe this is down to using `ubuntu-latest` which is currently 24.04.

Also took the time to update `actions/checkout` and `actions/setup-node` to the current major version - let's see if CI passes.